### PR TITLE
Various updates

### DIFF
--- a/dags/dependencies/flattener/constants.py
+++ b/dags/dependencies/flattener/constants.py
@@ -1,12 +1,11 @@
-#ROCESSOR_ENDPOINT = "https://ccc-flattener-eaf-dev-1061430463455.us-central1.run.app"
-PROCESSOR_ENDPOINT= "https://ccc-flattener-155089172944.us-central1.run.app"
+import os
 
-#BQ_PROJECT_ID = "nih-nci-dceg-connect-dev"
-BQ_PROJECT_ID = "nih-nci-dceg-connect-prod-6d04"
+PROCESSOR_ENDPOINT = os.environ.get("FLATTENER_PROCESSOR_ENDPOINT")
+GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
+GCS_FLATTENED_BUCKET = os.environ.get("GCS_FLATTENED_BUCKET")
+
 BQ_RAW_DATASET = "Connect"
 BQ_FLATTENED_DATASET = "FlatConnect"
-#GCS_FLATTENED_BUCKET = "flattener_tmp_dev"
-GCS_FLATTENED_BUCKET = "flattener_tmp"
 
 FIRESTORE_REFRESH_TOPIC = "schedule-firestore-backup"
 

--- a/dags/dependencies/flattener/flatten.py
+++ b/dags/dependencies/flattener/flatten.py
@@ -1,5 +1,6 @@
 import dependencies.flattener.utils as utils
 
+
 def flatten_parquet(table_id: str, destination_bucket) -> None:
     utils.logger.info(f"Flattening {table_id} Parquet files")
 

--- a/dags/dependencies/flattener/gcp.py
+++ b/dags/dependencies/flattener/gcp.py
@@ -1,5 +1,6 @@
 import dependencies.flattener.utils as utils
 
+
 def bq_to_parquet(project_id: str, dataset_id: str, table_id: str, destination_bucket) -> None:
     utils.logger.info(f"Saving {table_id} to Parquet file in {destination_bucket}")
 

--- a/dags/dependencies/flattener/utils.py
+++ b/dags/dependencies/flattener/utils.py
@@ -1,10 +1,10 @@
 import logging
-import sys
-import requests  # type: ignore
 import subprocess
-from typing import Optional, Any
+import sys
+from typing import Any, Optional
 
 import dependencies.flattener.constants as constants
+import requests  # type: ignore
 
 """
 Set up a logging instance that will write to stdout (and therefore show up in Google Cloud logs)

--- a/dags/flattener.py
+++ b/dags/flattener.py
@@ -21,7 +21,7 @@ default_args = {
 dag = DAG(
     'flattener',
     default_args=default_args,
-    description='Pipeline for flattening Connect study data',
+    description='Pipeline for flattening Connect survery data',
     schedule_interval='0 10 * * *',  # Daily at 10:00 AM UTC (6AM or 7AM ET depending on daylight savings)
     params={
         'trigger_firestore_backup': Param(


### PR DESCRIPTION
- Change API endpoint, GCS bucket, and GCP environment to environmental variables defied in Cloud Composer
- Change DAG to run at 10AM UTC (6AM or 7AM ET)
- Allow users to select specific tables to flatten when manually executing the DAG; by default, on scheduled runs, all tables are flattened